### PR TITLE
Add endpoint specific tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { IAPIResourceList, IBerry, IBerryFirmness, INamedAPIResourceList, TPokeAPIEndpoint, TPokeAPIResource } from './interfaces';
+import { IAPIResourceList, IBerry, IBerryFirmness, INamedAPIResourceList, IPokeAPIResource, TPokeAPIEndpoint } from './interfaces';
 import request from 'request-promise-native';
 
 export class PokeAPI {
@@ -9,7 +9,7 @@ export class PokeAPI {
   public async get<T extends IBerryFirmness>(endpoint: 'berry-firmness', filter: number | string): Promise<T>;
   public async get<T extends IBerry>(endpoint: 'berry'): Promise<INamedAPIResourceList>;
   public async get<T extends IBerry>(endpoint: 'berry', filter: number | string): Promise<T>;
-  public async get<T extends TPokeAPIResource>(endpoint: TPokeAPIEndpoint, filter?: number | string): Promise<T | IAPIResourceList | INamedAPIResourceList> {
+  public async get<T extends IPokeAPIResource>(endpoint: TPokeAPIEndpoint, filter?: number | string): Promise<T | IAPIResourceList | INamedAPIResourceList> {
     const url = this._constructUrl(endpoint, filter);
 
     return request(url)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -62,7 +62,6 @@ export interface INamedPokeAPIResource extends IPokeAPIResource {
 }
 
 // Additional Types
-export type TPokeAPIResource = IPokeAPIResource | INamedPokeAPIResource;
 export type TPokeAPIEndpoint =
   | 'berry'
   | 'berry-firmness'

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,3 +1,5 @@
+import { berryTests } from './support/endpoints/berry';
+import { berryFirmnessTests } from './support/endpoints/berry-firmness';
 import { expect } from 'chai';
 import { endpointRunner } from './support/endpoint-runner';
 import { IAPIResourceList, INamedAPIResourceList } from '../src/interfaces';
@@ -61,5 +63,5 @@ describe('internal methods', (): void => {
   });
 });
 
-endpointRunner('berry');
-endpointRunner('berry-firmness');
+endpointRunner('berry', berryTests);
+endpointRunner('berry-firmness', berryFirmnessTests);

--- a/test/support/endpoint-runner.ts
+++ b/test/support/endpoint-runner.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
-import { IAPIResource, IAPIResourceList, INamedAPIResource, INamedAPIResourceList, TPokeAPIEndpoint } from '../../src/interfaces';
+import { IAPIResource, IAPIResourceList, INamedAPIResource, INamedAPIResourceList, IPokeAPIResource, TPokeAPIEndpoint } from '../../src/interfaces';
 import { PokeAPIPublic } from '../support/pokeapi-public';
+import { isStringOrNull } from './type-guards';
 
-export function endpointRunner(endpoint: TPokeAPIEndpoint) {
+export function endpointRunner<T extends IPokeAPIResource>(endpoint: TPokeAPIEndpoint, itemTests: (resource: T) => void) {
   describe(`${endpoint}`, (): void => {
     const pokeapi: PokeAPIPublic = new PokeAPIPublic();
     let list: IAPIResourceList | INamedAPIResourceList | undefined;
@@ -12,8 +13,8 @@ export function endpointRunner(endpoint: TPokeAPIEndpoint) {
 
       expect(list.count).to.be.a('number');
       expect(list.count).to.be.greaterThan(0);
-      expect(list.next).to.satisfy(_isStringOrNull);
-      expect(list.previous).to.satisfy(_isStringOrNull);
+      expect(list.next).to.satisfy(isStringOrNull);
+      expect(list.previous).to.satisfy(isStringOrNull);
 
       if (pokeapi.listIsNamed(list)) {
         expect(list.results[0].name).to.be.a('string');
@@ -35,6 +36,8 @@ export function endpointRunner(endpoint: TPokeAPIEndpoint) {
         if (pokeapi.listIsNamed(list)) {
           expect(output.name).to.equal(list.results[randomIndex].name);
         }
+
+        itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
       }
     });
 
@@ -52,11 +55,9 @@ export function endpointRunner(endpoint: TPokeAPIEndpoint) {
         if (pokeapi.listIsNamed(list)) {
           expect(output.name).to.equal(list.results[randomIndex].name);
         }
+
+        itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
       }
     });
   });
-}
-
-function _isStringOrNull(value: string | null): value is string | null {
-  return value === null || typeof value === 'string';
 }

--- a/test/support/endpoints/berry-firmness.ts
+++ b/test/support/endpoints/berry-firmness.ts
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import { IBerryFirmness } from '../../../src/interfaces';
+import { isNameArray, isNamedAPIResourceArray } from '../type-guards';
+
+export function berryFirmnessTests(berryFirmness: IBerryFirmness) {
+  expect(berryFirmness.berries).to.satisfy(isNamedAPIResourceArray);
+  expect(berryFirmness.names).to.satisfy(isNameArray);
+}

--- a/test/support/endpoints/berry.ts
+++ b/test/support/endpoints/berry.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { IBerry } from '../../../src/interfaces';
+import { isBerryFlavorMapArray, isNamedAPIResource } from '../type-guards';
+
+export function berryTests(berry: IBerry) {
+  expect(berry.firmness).to.satisfy(isNamedAPIResource);
+  expect(berry.flavors).to.satisfy(isBerryFlavorMapArray);
+  expect(berry.growth_time).to.be.a('number');
+  expect(berry.item).to.satisfy(isNamedAPIResource);
+  expect(berry.max_harvest).to.be.a('number');
+  expect(berry.natural_gift_power).to.be.a('number');
+  expect(berry.natural_gift_type).to.satisfy(isNamedAPIResource);
+  expect(berry.size).to.be.a('number');
+  expect(berry.smoothness).to.be.a('number');
+  expect(berry.soil_dryness).to.be.a('number');
+}

--- a/test/support/type-guards.ts
+++ b/test/support/type-guards.ts
@@ -1,0 +1,50 @@
+import { IBerryFlavorMap, IName, INamedAPIResource } from '../../src/interfaces';
+
+// BerryFlavorMap
+export function isBerryFlavorMap(resource: any): resource is IBerryFlavorMap {
+  return isNamedAPIResource(resource.flavor) && typeof resource.potency === 'number';
+}
+
+export function isBerryFlavorMapArray(resource: any): resource is IBerryFlavorMap[] {
+  return _isResourceArray(resource, isBerryFlavorMap);
+}
+
+// Name
+export function isName(resource: any): resource is IName {
+  return typeof resource.name === 'string' && isNamedAPIResource(resource.language);
+}
+
+export function isNameArray(resource: any): resource is IName[] {
+  return _isResourceArray(resource, isName);
+}
+
+// NamedAPIResource
+export function isNamedAPIResource(resource: any): resource is INamedAPIResource {
+  return typeof resource.name === 'string' && typeof resource.url === 'string';
+}
+
+export function isNamedAPIResourceArray(resource: any): resource is INamedAPIResource[] {
+  return _isResourceArray(resource, isNamedAPIResource);
+}
+
+// Utility
+export function isStringOrNull(value: any): value is string | null {
+  return _isNull(value) || _isString(value);
+}
+
+function _isNull(value: any): value is null {
+  return value === null;
+}
+
+function _isString(value: any): value is string {
+  return typeof value === 'string';
+}
+
+function _isResourceArray<T extends any>(resource: T[], resourceCheckMethod: (internalResource: T) => boolean) {
+  const isArray = Array.isArray(resource);
+  const contentsCheck = resource.every(value => {
+    return resourceCheckMethod(value);
+  });
+
+  return isArray && contentsCheck;
+}


### PR DESCRIPTION
* Remove `TPokeAPIResource` type as it was unnecessary
* Add endpoint specific tests for `berry` and `berry-firmness`
* Split type guard methods into separate file