### PR TITLE
Add `contest-effect` tests and interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,16 @@ export class PokeAPI {
   protected static _API_VERSION: string = 'v2';
   protected static _BASE: string = 'https://pokeapi.co';
 
-  public async get<T extends IContestType>(endpoint: 'contest-type'): Promise<INamedAPIResourceList>;
-  public async get<T extends IContestType>(endpoint: 'contest-type', filter: number | string): Promise<T>;
-  public async get<T extends IBerryFlavor>(endpoint: 'berry-flavor'): Promise<INamedAPIResourceList>;
-  public async get<T extends IBerryFlavor>(endpoint: 'berry-flavor', filter: number | string): Promise<T>;
-  public async get<T extends IBerryFirmness>(endpoint: 'berry-firmness'): Promise<INamedAPIResourceList>;
-  public async get<T extends IBerryFirmness>(endpoint: 'berry-firmness', filter: number | string): Promise<T>;
   public async get<T extends IBerry>(endpoint: 'berry'): Promise<INamedAPIResourceList>;
   public async get<T extends IBerry>(endpoint: 'berry', filter: number | string): Promise<T>;
+  public async get<T extends IBerryFirmness>(endpoint: 'berry-firmness'): Promise<INamedAPIResourceList>;
+  public async get<T extends IBerryFirmness>(endpoint: 'berry-firmness', filter: number | string): Promise<T>;
+  public async get<T extends IBerryFlavor>(endpoint: 'berry-flavor'): Promise<INamedAPIResourceList>;
+  public async get<T extends IBerryFlavor>(endpoint: 'berry-flavor', filter: number | string): Promise<T>;
+  public async get<T extends IContestType>(endpoint: 'contest-type'): Promise<INamedAPIResourceList>;
+  public async get<T extends IContestType>(endpoint: 'contest-type', filter: number | string): Promise<T>;
+  public async get<T extends IContestType>(endpoint: 'contest-effect'): Promise<IAPIResourceList>;
+  public async get<T extends IContestType>(endpoint: 'contest-effect', filter: number): Promise<T>;
   public async get<T extends IPokeAPIResource>(endpoint: TPokeAPIEndpoint, filter?: number | string): Promise<T | IAPIResourceList | INamedAPIResourceList> {
     const url: string = this._constructUrl(endpoint, filter);
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -62,9 +62,27 @@ export interface IContestName {
   name: string;
 }
 
-// Utility
+// Contest Effects
+export interface IContestEffect extends IPokeAPIResource {
+  appeal: number;
+  effect_entries: IEffect[];
+  flavor_text_entries: IFlavorText[];
+  jam: number;
+}
+
+// Utility - Common Models
 export interface IAPIResource {
   url: string;
+}
+
+export interface IEffect {
+  effect: string;
+  language: INamedAPIResource; // Language
+}
+
+export interface IFlavorText {
+  flavor_text: string;
+  language: INamedAPIResource; // Language
 }
 
 export interface IName {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { endpointRunner } from './support/endpoint-runner';
-import { berryFirmnessTests, berryFlavorTests, berryTests, contestTypeTests } from './support/endpoints';
+import { berryFirmnessTests, berryFlavorTests, berryTests, contestEffectTests, contestTypeTests } from './support/endpoints';
 import { IAPIResourceList, INamedAPIResourceList } from '../src/interfaces';
 import { PokeAPIPublic } from './support/pokeapi-public';
 
@@ -66,3 +66,4 @@ endpointRunner('berry', berryTests);
 endpointRunner('berry-firmness', berryFirmnessTests);
 endpointRunner('berry-flavor', berryFlavorTests);
 endpointRunner('contest-type', contestTypeTests);
+endpointRunner('contest-effect', contestEffectTests);

--- a/test/support/endpoint-runner.ts
+++ b/test/support/endpoint-runner.ts
@@ -49,8 +49,9 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
       }
     });
 
+    // TODO: Figure out how to cancel this test entirely if the name property is not applicable
     it(`gets a ${endpoint} by name`, async (): Promise<void> => {
-      if (list) {
+      if (list && pokeapi.listIsNamed(list)) {
         const randomIndex: number = Math.floor(Math.random() * (Math.floor(list.count - 1) + 1));
         const result: IAPIResource | INamedAPIResource = list.results[randomIndex];
         const urlParts: string[] = result.url.split('/');

--- a/test/support/endpoints/contest-effects.ts
+++ b/test/support/endpoints/contest-effects.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import { IContestEffect } from '../../../src/interfaces';
+import { isEffectArray, isFlavorTextArray } from '../type-guards';
+
+export function contestEffectTests(contestEffect: IContestEffect): void {
+  expect(contestEffect.appeal).to.be.a('number');
+  expect(contestEffect.effect_entries).to.satisfy(isEffectArray);
+  expect(contestEffect.flavor_text_entries).to.satisfy(isFlavorTextArray);
+  expect(contestEffect.jam).to.be.a('number');
+}

--- a/test/support/endpoints/index.ts
+++ b/test/support/endpoints/index.ts
@@ -2,3 +2,4 @@ export { berryTests } from './berry';
 export { berryFirmnessTests } from './berry-firmness';
 export { berryFlavorTests } from './berry-flavor';
 export { contestTypeTests } from './contest-types';
+export { contestEffectTests } from './contest-effects';

--- a/test/support/type-guards.ts
+++ b/test/support/type-guards.ts
@@ -1,4 +1,4 @@
-import { IBerryFlavorMap, IContestName, IFlavorBerryMap, IName, INamedAPIResource } from '../../src/interfaces';
+import { IBerryFlavorMap, IContestName, IEffect, IFlavorBerryMap, IFlavorText, IName, INamedAPIResource } from '../../src/interfaces';
 
 // BerryFlavorMap
 function isBerryFlavorMap(resource: IBerryFlavorMap): resource is IBerryFlavorMap {
@@ -25,6 +25,24 @@ function isContestName(resource: IContestName): resource is IContestName {
 
 export function isContestNameArray(resource: IContestName[]): resource is IContestName[] {
   return _isResourceArray(resource, isContestName);
+}
+
+// Effect
+function isEffect(resource: IEffect): resource is IEffect {
+  return typeof resource.effect === 'string' && isNamedAPIResource(resource.language);
+}
+
+export function isEffectArray(resource: IEffect[]): resource is IEffect[] {
+  return _isResourceArray(resource, isEffect);
+}
+
+// FlavorText
+function isFlavorText(resource: IFlavorText): resource is IFlavorText {
+  return typeof resource.flavor_text === 'string' && isNamedAPIResource(resource.language);
+}
+
+export function isFlavorTextArray(resource: IFlavorText[]): resource is IFlavorText[] {
+  return _isResourceArray(resource, isFlavorText);
 }
 
 // Name
@@ -58,6 +76,7 @@ function _isString(value: string): value is string {
   return typeof value === 'string';
 }
 
+// TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
 function _isResourceArray<T extends any>(resource: T[], resourceCheckMethod: (internalResource: T) => boolean): boolean {
   const isArray: boolean = Array.isArray(resource);
   const contentsCheck: boolean = resource.every((value: T) => {


### PR DESCRIPTION
* Reorganize src/index
* Only run name-based tests if type is searchable by name